### PR TITLE
Silencing package loads

### DIFF
--- a/Inst/ThreadNet/global.R
+++ b/Inst/ThreadNet/global.R
@@ -12,26 +12,26 @@
 
 
 # add the dependent packages
-library(shiny)
-library(shinyjs)
-library(plotly)
-library(ggplot2)
-library(tidyverse)
-library(ngram)
-library(stringr)
-library(stringdist)
-library(igraph)
-library(networkD3)
-library(visNetwork)
-library(xesreadR)
-library(colorspace)
-library(DT)
-library(RColorBrewer)
-library(lubridate)
-library(knitr)
-library(ThreadNet)
-
-
+suppressPackageStartupMessages({
+	library(shiny)
+	library(shinyjs)
+	library(plotly)
+	library(ggplot2)
+	library(tidyverse)
+	library(ngram)
+	library(stringr)
+	library(stringdist)
+	library(igraph)
+	library(networkD3)
+	library(visNetwork)
+	library(xesreadR)
+	library(colorspace)
+	library(DT)
+	library(RColorBrewer)
+	library(lubridate)
+	library(knitr)
+	library(ThreadNet)
+})
 
 # visualization types for UI dropdowns
 visualizations <- c(


### PR DESCRIPTION
I think the software will look much more ready-to-use (and much less threatening for the fainthearted) if you can get rid of the unnecessary REPL messages. It will also help the troubleshooting when people come back to you with questions about the errors, as they will only see the necessary warnings and error messages. Here is an example, just suppressing the initial package load messages.