### PR TITLE
add function to allow shinyServer to host app directly from package

### DIFF
--- a/R/runExample.R
+++ b/R/runExample.R
@@ -1,0 +1,9 @@
+#' @export
+runExample <- function() {
+  appDir <- system.file("ThreadNet", package = "ThreadNet")
+  if (appDir == "") {
+    stop("Could not find shiny app directory. Try re-installing `ThreadNet`.", call. = FALSE)
+  }
+
+  shiny::runApp(appDir, display.mode = "normal")
+}


### PR DESCRIPTION
Adds one new file "R/runExample.R" which contains a single function, "runExample()". This function enables the ThreadNet app to be persistently served via shinyServer. See https://deanattali.com/2015/04/21/r-package-shiny-app/ for more details.